### PR TITLE
hotfix(menu): mejorar comportamiento del menu lateral y cerrarlo auto…

### DIFF
--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -1,28 +1,32 @@
 <ion-app>
-  <ion-menu
-    contentId="main-content"
-    [disabled]="false"
-    [swipeGesture]="true"
-    type="push"
-  >
+  <ion-menu contentId="main-content" [swipeGesture]="true" type="overlay">
     <ion-header>
       <ion-toolbar>
         <ion-title>Menú</ion-title>
       </ion-toolbar>
     </ion-header>
+
     <ion-content>
       <ion-list>
-        <ion-item routerLink="/home" routerDirection="root" detail="false">
+        <ion-item
+          (click)="onNavigate()"
+          (keyDown)="onNavigate()"
+          detail="false"
+          routerLink="/home"
+        >
           <ion-label>Inicio</ion-label>
         </ion-item>
-        <ion-item routerLink="/add-task" routerDirection="root" detail="false">
+        <ion-item
+          (click)="onNavigate()"
+          (keyDown)="onNavigate()"
+          detail="false"
+          routerLink="/add-task"
+        >
           <ion-label>Agregar Tarea</ion-label>
         </ion-item>
       </ion-list>
     </ion-content>
   </ion-menu>
 
-  <div class="ion-page" id="main-content">
-    <ion-router-outlet></ion-router-outlet>
-  </div>
+  <ion-router-outlet id="main-content"></ion-router-outlet>
 </ion-app>

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MenuController } from '@ionic/angular';
 
 import { StorageService } from '../services/storage.service';
 
@@ -9,7 +10,10 @@ import { StorageService } from '../services/storage.service';
   standalone: false,
 })
 export class Layout implements OnInit {
-  constructor(private readonly storageService: StorageService) {}
+  constructor(
+    private readonly storageService: StorageService,
+    private readonly menuCtrl: MenuController
+  ) {}
 
   ngOnInit(): void {
     this.getAll();
@@ -17,5 +21,9 @@ export class Layout implements OnInit {
 
   private async getAll() {
     await this.storageService.init();
+  }
+
+  async onNavigate() {
+    await this.menuCtrl.close();
   }
 }


### PR DESCRIPTION
…maticamente al navegar

Se han realizado los siguientes ajustes:
- Se modifico el tipo de menu de push a overlay para mostrarlo por encima del contenido actual
- Ahora el menu no desplaza toda la pantalla hacia un lado sino que aparece como superposicion
- Se agrego la logica para cerrar automaticamente el menu al seleccionar una opcion
- Se utilizo MenuController de @ionic/angular para controlar el estado del menu
- Se corrigio error de componentes desconocidos en layout.page.html
- Se aseguro la importacion correcta de IonicModule en LayoutPageModule
- Se mejoro la experiencia de usuario en navegacion movil y web